### PR TITLE
ci: docker test step using container-structure-test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -280,7 +280,6 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: [build,lint,test]
-    if: github.event_name != 'pull_request'
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -290,6 +289,12 @@ jobs:
       with:
         images: ${{ github.repository }}
         tag-sha: true
+        label-custom: |
+          org.opencontainers.image.authors=${{ secrets.OCI_AUTHORS }}
+          org.opencontainers.image.documentation=https://github.com/${{ github.repository }}
+          org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          org.opencontainers.image.url=https://github.com/${{ github.repository }}
+          org.opencontainers.image.vendor=${{ secrets.OCI_AUTHORS }}
         github-token: ${{ github.token }}
     - name: set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -308,26 +313,45 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: build and publish image
+    - name: build image
       uses: docker/build-push-action@v2
       env:
-        DOCKER_BUILDKIT: 1
+        DOCKER_BUILDKIT: 0
         BUILDKIT_INLINE_CACHE: 1
       with:
+        push: false
+        load: true
+        labels: ${{ steps.docker_meta.outputs.labels }}
         cache-to: type=inline
         cache-from: |
           ${{ steps.docker_meta.outputs.tags }}
           ${{ github.repository }}:master
           ${{ github.repository }}:latest
+        tags: ${{ github.repository }}:test
+    - name: test image
+      uses: brpaz/structure-tests-action@v1.1.2
+      with:
+        image: ${{ github.repository }}:test
+        configFile: docker-test.yaml
+    - name: push image
+      if: github.event_name != 'pull_request'
+      uses: docker/build-push-action@v2
+      env:
+        DOCKER_BUILDKIT: 1
+        BUILDKIT_INLINE_CACHE: 1
+      with:
         push: true
         platforms: linux/amd64,linux/arm/v7,linux/arm64
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        cache-to: type=inline
+        cache-from: |
+          ${{ steps.docker_meta.outputs.tags }}
+          ${{ github.repository }}:test
+          ${{ github.repository }}:master
+          ${{ github.repository }}:latest
         tags: ${{ steps.docker_meta.outputs.tags }}
-        labels: |
-          ${{ steps.docker_meta.outputs.labels }}
-          org.opencontainers.image.authors=${{ secrets.OCI_AUTHORS }}
-          org.opencontainers.image.documentation=https://github.com/${{ github.repository }}
-          org.opencontainers.image.vendor=${{ secrets.OCI_AUTHORS }}
     - name: update DockerHub description
+      if: github.event_name != 'pull_request'
       uses: meeDamian/sync-readme@v1.0.6
       with:
         pass: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -312,11 +312,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile', '.dockerignore') }}
           ${{ runner.os }}-buildx-
-    - name: login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
     - name: build image
       uses: docker/build-push-action@v2
       env:
@@ -337,6 +332,12 @@ jobs:
       with:
         image: ${{ github.repository }}:test
         configFile: docker-test.yaml
+    - name: login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
     - name: push image
       if: github.event_name != 'pull_request'
       uses: docker/build-push-action@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -288,7 +288,11 @@ jobs:
       uses: crazy-max/ghaction-docker-meta@v1
       with:
         images: ${{ github.repository }}
-        tag-sha: true
+        tag-edge: true
+        tag-semver: |
+          {{version}}
+          {{major}}
+          {{major}}.{{minor}}
         label-custom: |
           org.opencontainers.image.authors=${{ secrets.OCI_AUTHORS }}
           org.opencontainers.image.documentation=https://github.com/${{ github.repository }}

--- a/docker-test.yaml
+++ b/docker-test.yaml
@@ -48,10 +48,10 @@ metadataTest:
     value: 'https://.+'
     isRegex: true
   - key: org.opencontainers.image.version
-    value: '^\d{1}\.\d{1}\.\d{1}(-\w+)?(\+\w+)?$'
+    value: '^\d{1}\.\d{1}\.\d{1}(-\w+)?(\+\w+)?$|^pr-\d+$|^(master|latest)$'
     isRegex: true
   - key: org.opencontainers.image.created
-    value: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$'
+    value: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$'
     isRegex: true
   - key: org.opencontainers.image.revision
     value: '^[\w-.]+$'


### PR DESCRIPTION
# CI changes

- enabled docker job for PRs
- splitted docker build and push step
- disabled docker push step on PRs
- disabled docker hub description update on PRs
- added a step to validade the docker image structure using [container-structure-test](https://github.com/GoogleContainerTools/container-structure-test)
- replaced the sha tag generation with edge tagging
- enabled semantic version tags for major and major+minor
- moved custom labels to the meta generator step