### PR TITLE
ci: fix grype cache path due to runner context limitations

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -281,7 +281,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, lint, test]
     env:
-      GRYPE_DB_CACHE_DIR: ${{ runner.temp }}/.cache/grype/db/
+      # runner context is not available here...
+      GRYPE_DB_CACHE_TEMP_PATH: .cache/grype/db/
     steps:
     - name: checkout
       uses: actions/checkout@v2
@@ -352,7 +353,7 @@ jobs:
     - name: cache grype
       uses: pat-s/always-upload-cache@v2.1.5
       with:
-        path: ${{ env.GRYPE_DB_CACHE_DIR }}
+        path: ${{ runner.temp }}/${{ env.GRYPE_DB_CACHE_TEMP_PATH }}
         key: ${{ runner.os }}-grype-${{ hashFiles('.grype.yaml') }}
         restore-keys: |
           ${{ runner.os }}-grype-${{ hashFiles('.grype.yaml') }}


### PR DESCRIPTION
# Changes

<!-- describe here the changes introduced -->

## Non-breaking

- [ ] `feat` - adds functionality for the user
- [ ] `fix` - fixes an issue for the user
- [ ] `docs` - changes to the documentation
- [ ] `style` - formatting, missing semi colons, etc
- [ ] `refactor` - refactoring production code, eg. renaming a variable
- [ ] `test` - adding missing tests, refactoring tests
- [x] `chore` - configuration of lint, IDE, issue template, etc

## Breaking

- [ ] `feat!` - adds functionality for the user, but changes existing
functionality
- [ ] `fix!` - fixes an issue for the user, but changes existing functionality
- [ ] `refactor!` - changes that replaces existing functionality, eg. changing
the arity of a function
- [ ] `chore!` - updating yarn/lerna scripts, etc
